### PR TITLE
feat: change color assets name to pascal case

### DIFF
--- a/Quack/Extensions/ColorManager.swift
+++ b/Quack/Extensions/ColorManager.swift
@@ -13,21 +13,21 @@ extension Color {
         case "#EFEEDF":
             self.init(.alabaster)
         case "#D7D5C1":
-            self.init(.pastelgray)
+            self.init(.pastelGray)
         case "#A8A7A1":
-            self.init(.quicksilver)
+            self.init(.quickSilver)
         case "#68675E":
-            self.init(.granitegray)
+            self.init(.graniteGray)
         case "#525250":
-            self.init(.davysgray)
+            self.init(.davysGray)
         case "#323230":
-            self.init(.darkcharcoal)
+            self.init(.darkCharcoal)
         case "#2A2925":
-            self.init(.pinetree)
+            self.init(.pineTree)
         case "#21211D":
-            self.init(.raisinblack)
+            self.init(.raisinBlack)
         case "#171714":
-            self.init(.chineseblack)
+            self.init(.chineseBlack)
         default:
             self.init(.clear)
         }


### PR DESCRIPTION
## 📋 관련된 이슈 번호 (Related issue Number)
- #11 

## 🛠️ 작업 사항 (Working details)
- 최소 지원 버젼 설정
  - SwiftData 활용을 위해 17.0으로 설정
- 앱 카테고리 설정
- 지원 방향 설정
- 지원 기기 설정
- Color assets 추가
  - ColorManager.swift를 통해 hex코드값을 통해 color 사용가능 하도록 설정
- Font assets 추가 

## ✏️ 변경 사항 (Changing details)
-

## ➕ 특이 사항 (Additional details)
- Display name 추후 추가 예정
- 10/feat 브랜치에서 FontManager.swift의 number case 추가 예정 
